### PR TITLE
投稿削除機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/_posts.scss
+++ b/app/assets/stylesheets/modules/_posts.scss
@@ -165,9 +165,23 @@
         .favorites-count {
           padding-left: 7px;
         }
-        // &__icon {
-        //   padding-left: 50px;
-        // }
+      }
+    }
+    .link-btn {
+      display: flex;
+      justify-content: space-between;
+      margin: 0 auto;
+      width: 20%;
+      font-size: 25px;
+      .link-edit-btn {
+        border: solid 1px #0071e3;
+        border-radius: 10px;
+        padding: 3px 10px;
+      }
+      .link-delete-btn {
+        border: solid 1px #0071e3;
+        border-radius: 10px;
+        padding: 3px 10px;
       }
     }
   }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -26,6 +26,13 @@ class PostsController < ApplicationController
   end
 
   def destroy
+    @post = Post.find(params[:id])
+    if @post.destroy
+      redirect_to root_path, notice: "削除が完了しました"
+    else
+      flash[:alert] = "削除できませんでした"
+      render :show
+    end
   end
 
   def show
@@ -33,7 +40,7 @@ class PostsController < ApplicationController
     @user = User.find_by(id: @post.user_id)
     @images = Image.where(post_id: @post.id)
     @favorite = Favorite.find_by(user_id: current_user.id, post_id: @post.id)
-    @avorites = Favorite.all
+    @favorites = Favorite.all
   end
 
   private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
   validates :images, presence: true
-  has_many :images
+  has_many :images, dependent: :destroy
   has_many :favorites, dependent: :destroy
   belongs_to :user
   # belongs_to :group

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -18,10 +18,17 @@
         <div class="favorites-count">
           <%= @post.favorites.size %>
         </div>
-        <%# <%= link_to "https://twitter.com/", class: "bottom__icon" do %>
-          <%# <i class="fab fa-twitter"></i> %>
-        <%# <% end %>
       </div>
     </div>
+    <% if @post.user_id == current_user.id %>
+      <div class="link-btn">
+        <div class="link-edit-btn">
+          <%= link_to "編集", edit_post_path(@post.id) %>
+        </div>
+        <div class="link-delete-btn">
+          <%= link_to "削除", "/posts/#{@post.id}", method: :delete %>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
# What
投稿データの削除機能を実装
# Why
今後実装予定のユーザーマイページが投稿データに溢れ使いづらくならないようにするため